### PR TITLE
fix(dashboard): handle final stream events without message

### DIFF
--- a/dashboard/src/stores/chat.ts
+++ b/dashboard/src/stores/chat.ts
@@ -551,7 +551,26 @@ export const useChatStore = create<ChatState>()((set, get) => ({
       }
 
       case 'final': {
-        if (!event.message) return;
+        if (!event.message) {
+          // MiniMax and some providers send final without a message body.
+          // Clear streaming state and reload history to show the result.
+          if (event.runId === runId || (get().streaming && !runId)) {
+            set({ streaming: false, streamText: null, runId: null });
+            get().loadHistory();
+            setTimeout(() => {
+              useLibraryStore.getState().loadPapers();
+              useLibraryStore.getState().loadTags();
+              useTasksStore.getState().loadTasks();
+              useSessionsStore.getState().loadSessions();
+              useRadarStore.getState().loadConfig();
+              useCronStore.getState().loadPresets();
+              useUiStore.getState().triggerWorkspaceRefresh();
+              useUiStore.getState().checkNotifications();
+              get().loadSessionUsage();
+            }, 500);
+          }
+          return;
+        }
         // Skip tool result messages — not user-visible
         if (!isVisibleRole(event.message.role)) return;
         const text = extractText(event.message);


### PR DESCRIPTION
## Summary
- fix dashboard chat streaming for providers that emit `final` events without a `message` payload (e.g. MiniMax-compatible behavior)
- when `final` arrives without `message`, clear streaming state and reload history so the assistant reply is shown immediately
- preserve existing behavior for providers that include `message` in `final`

## Test plan
- [x] Reproduce with MiniMax: send a message and verify UI no longer stays in "thinking" forever
- [x] Confirm reply appears without manual page refresh
- [x] Build dashboard successfully (`pnpm --filter dashboard build`)

Made with [Cursor](https://cursor.com)