### PR TITLE
fix: 更新流程保护 workspace 文件并统一 uploads 文档

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,13 @@ extensions/*/package-lock.json
 # All prompt files live in workspace/.ResearchClaw/ (loaded via agent:bootstrap hook).
 # Root-level copies are OC defaults — not RC content — and must not be tracked.
 # Only workspace/AGENTS.md (pointer to .ResearchClaw/) is git-tracked at root.
+workspace/*
+!workspace/.gitignore
+!workspace/.ResearchClaw/
+!workspace/AGENTS.md
+!workspace/AGENTS.md.example
+!workspace/MEMORY.md.example
+!workspace/USER.md.example
 workspace/SOUL.md
 workspace/IDENTITY.md
 workspace/TOOLS.md

--- a/docs/modules/03c-workspace-git-tracking.md
+++ b/docs/modules/03c-workspace-git-tracking.md
@@ -53,7 +53,7 @@ researchers face when working with AI agents:
 | Principle | Rule |
 |-----------|------|
 | **Local-only by default** | Git repo lives in the workspace directory. No remote is configured automatically. The agent NEVER pushes. |
-| **Source/output separation** | User-provided files go under `sources/`. Agent-generated files go under `outputs/`. This boundary is enforced by convention (tool descriptions), not by hard filesystem locks. |
+| **Upload/output separation** | Dashboard-uploaded files go under `uploads/`. Agent-generated files go under `outputs/`. This boundary is enforced by convention (tool descriptions), not by hard filesystem locks. |
 | **Descriptive commits** | Every auto-commit includes a human-readable message that names the action and, where applicable, the related project or paper. |
 | **No data loss** | Overwriting a tracked file always produces a new commit first. The researcher can restore any prior version. |
 | **Large-file safety** | Files exceeding 10 MB are listed in `.gitignore` by default to prevent repository bloat. The user can override this. |
@@ -66,10 +66,10 @@ researchers face when working with AI agents:
 workspace/
 ├── .git/                 # Auto-initialized, local-only
 ├── .gitignore            # Generated on init (see template below)
-├── sources/              # User uploads, reference materials
-│   ├── papers/           # Downloaded PDFs
-│   ├── data/             # Datasets, raw data (CSV, JSON, XLSX, etc.)
-│   └── references/       # BibTeX files, reading notes, annotations
+├── uploads/              # User uploads, reference materials
+│   ├── papers/           # Uploaded PDFs
+│   ├── data/             # Uploaded datasets (CSV, JSON, XLSX, etc.)
+│   └── references/       # Uploaded BibTeX, notes, annotations
 └── outputs/              # Agent-generated files
     ├── drafts/           # Writing drafts (Markdown, LaTeX, DOCX)
     ├── figures/          # Generated charts, plots, diagrams
@@ -91,7 +91,7 @@ with all subdirectories and initializes a Git repository.
 ### 2.2 Auto-Init Sequence
 
 ```
-1. mkdir -p workspace/{sources/{papers,data,references},outputs/{drafts,figures,exports,reports}}
+1. mkdir -p workspace/{uploads/{papers,data,references},outputs/{drafts,figures,exports,reports}}
 2. cd workspace && git init
 3. git config user.name "Research-Claw"
 4. git config user.email "research-claw@wentor.ai"
@@ -145,7 +145,7 @@ All auto-commits follow a prefix convention:
 | `Init:` | Workspace creation | `Init: workspace created` |
 | `Add:` | New file saved | `Add: literature review draft for [quantum computing]` |
 | `Update:` | Existing file modified | `Update: figure 3 — revised color scheme` |
-| `Upload:` | File uploaded via dashboard | `Upload: smith2024.pdf to sources/papers` |
+| `Upload:` | File uploaded via dashboard | `Upload: smith2024.pdf to uploads/papers` |
 | `Restore:` | File restored from history | `Restore: draft.md to version abc1234` |
 | `Delete:` | File removed | `Delete: outdated export results.csv` |
 
@@ -634,7 +634,7 @@ Multipart file upload for the dashboard drag-drop feature.
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `file` | Binary | Yes | The file to upload |
-| `destination` | String | No | Relative path under workspace root. Default: `sources/` |
+| `destination` | String | No | Relative path under workspace root. Default: `uploads/` |
 
 #### Response (200 OK)
 
@@ -643,7 +643,7 @@ Multipart file upload for the dashboard drag-drop feature.
   "ok": true,
   "file": {
     "name": "smith2024.pdf",
-    "path": "sources/papers/smith2024.pdf",
+    "path": "uploads/smith2024.pdf",
     "type": "file",
     "size": 2458624,
     "mime_type": "application/pdf",
@@ -679,7 +679,7 @@ server.registerHttpRoute({
       return res.status(400).json({ error: 'UPLOAD_NO_FILE' });
     }
 
-    const destination = sanitizePath(fields.destination ?? 'sources/');
+    const destination = sanitizePath(fields.destination ?? 'uploads/');
 
     // 2. Write to temp location
     const tmpPath = path.join(os.tmpdir(), `rc-upload-${Date.now()}`);
@@ -720,7 +720,7 @@ renders the git history as a vertical timeline grouped by date.
     │  │    2 files changed                         │
     │  │                                            │
     │  ●─── def5678  11:15                         │
-    │  │    Upload: smith2024.pdf to sources/papers │
+    │  │    Upload: smith2024.pdf to uploads/       │
     │  │    1 file changed                          │
     │  │                                            │
     │  March 10, 2026                              │

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -393,8 +393,8 @@ if [ -d "$INSTALL_DIR/.git" ]; then
   git merge --abort 2>/dev/null || true
   git reset --hard HEAD 2>/dev/null || true
   # Remove untracked files that may conflict with incoming changes.
-  # Gitignored files (config, data, node_modules, workspace runtime) are preserved.
-  git clean -fd 2>/dev/null || true
+  # Keep all user workspace files even if they are not gitignored.
+  git clean -fd -e workspace/ 2>/dev/null || true
   if ! (git pull --rebase --autostash 2>/dev/null || git pull); then
     warn "git pull failed. Possible causes:"
     warn "  - Network issue (try again later)"


### PR DESCRIPTION
## 概要
- 修复更新脚本在 `git clean` 时可能误删 `workspace/` 下用户文件的问题，改为显式排除 `workspace/`。
- 在根 `.gitignore` 增加 `workspace/*` 兜底忽略规则，并保留必要模板/配置白名单，降低误删风险。
- 将工作区上传相关文档统一为 `uploads/` 默认路径，修正文档与实际实现不一致。

## 测试计划
- [x] 本地检查 `scripts/install.sh` 差异，确认 `git clean -fd -e workspace/` 生效。
- [x] 本地检查 `.gitignore` 差异，确认 `workspace/*` 与例外规则正确。
- [x] 全局检索 docs 中上传默认路径描述，确认已统一为 `uploads/`。
- [x] 手动执行 `git clean -fdn` 验证预览列表不包含 `workspace/` 文件（建议评审环境复核）。

Made with [Cursor](https://cursor.com)