### PR TITLE
fix: 修复 research-claw-core 在单次 boot 中重复注册

### DIFF
--- a/extensions/research-claw-core/index.ts
+++ b/extensions/research-claw-core/index.ts
@@ -106,6 +106,7 @@ interface PluginDefinition {
 // initialized once and reused — creating duplicates wastes file handles
 // and causes git lock races.
 let _initialized = false;
+let _registrationDone = false;
 let _dbManager: DatabaseManager | null = null;
 let _litService: InstanceType<typeof LiteratureService> | null = null;
 let _taskService: InstanceType<typeof TaskService> | null = null;
@@ -258,9 +259,11 @@ const plugin: PluginDefinition = {
         _toolCallProbeCache = new Map();
         _lastProbeResult = null;
         _initialized = false;
+        _registrationDone = false;
       },
     });
 
+    if (!_registrationDone) {
     // ── 4. Register tools (39 total) ─────────────────────────────────
     for (const tool of createLiteratureTools(litService)) {
       api.registerTool(tool);
@@ -1051,6 +1054,8 @@ const plugin: PluginDefinition = {
     }
 
     api.logger.info('Research-Claw Core registered (39 tools, 79 WS RPC + 1 HTTP = 80 interfaces, 8 hooks)');
+    _registrationDone = true;
+    }
   },
 };
 


### PR DESCRIPTION
## 背景

修复 [#46](https://github.com/wentorai/Research-Claw/issues/46) 中反馈的持续报错：

- `HTTP 400: Invalid request: tool call id workspace_save:44 is duplicated`

问题根因之一是 `research-claw-core` 在同一次 gateway boot 中可能被重复调用 `register()`，从而重复注册 tools / RPC / hooks，导致 `workspace_save` 这类工具存在重复执行风险。

## 修复内容

在 `extensions/research-claw-core/index.ts` 中新增注册幂等保护：

- 新增模块级 `_registrationDone` 标记
- 仅在首次 `register()` 时注册 tools / RPC / hooks / HTTP 接口
- 在 service `stop()` 中重置 `_registrationDone`，保证下次真正重启后仍可正常注册

## 影响

修复后，同一次 gateway boot 内即使 `register()` 被调用多次，也不会再次重复注册 `research-claw-core` 的能力项，从而避免同一 tool call 收到重复结果的风险。

## 验证

- `git diff --check`
- 在干净 worktree 中确认本次变更仅修改 `extensions/research-claw-core/index.ts`

说明：独立 worktree 未安装 `node_modules`，因此未在该 worktree 内执行 TypeScript 类型检查。

Closes #46