### PR TITLE
迁移 Research-Claw 本地数据目录到 ~/.research-claw，并在安装阶段强制初始化 ppt-master

### DIFF
--- a/config/openclaw.example.json
+++ b/config/openclaw.example.json
@@ -88,7 +88,7 @@
       "research-claw-core": {
         "enabled": true,
         "config": {
-          "dbPath": ".research-claw/library.db",
+          "dbPath": "~/.research-claw/library.db",
           "autoTrackGit": true,
           "defaultCitationStyle": "apa",
           "heartbeatDeadlineWarningHours": 48,

--- a/dashboard/src/__fixtures__/gateway-payloads/extensions-responses.ts
+++ b/dashboard/src/__fixtures__/gateway-payloads/extensions-responses.ts
@@ -179,7 +179,7 @@ export const CONFIG_GET_RESPONSE = {
         'research-claw-core': {
           enabled: true,
           config: {
-            dbPath: '.research-claw/library.db',
+            dbPath: '~/.research-claw/library.db',
             autoTrackGit: true,
             defaultCitationStyle: 'apa',
             heartbeatDeadlineWarningHours: 48,

--- a/dashboard/src/components/panels/ExtensionsPanel.test.tsx
+++ b/dashboard/src/components/panels/ExtensionsPanel.test.tsx
@@ -213,7 +213,7 @@ describe('ExtensionsPanel', () => {
           name: 'research-claw-core',
           enabled: true,
           path: 'extensions/research-claw-core',
-          config: { dbPath: '.research-claw/library.db' },
+          config: { dbPath: '~/.research-claw/library.db' },
         },
       ],
       pluginsLoaded: true,

--- a/dashboard/src/stores/extensions.test.ts
+++ b/dashboard/src/stores/extensions.test.ts
@@ -185,7 +185,7 @@ describe('loadPlugins', () => {
     expect(plugins[0].name).toBe('research-claw-core');
     expect(plugins[0].enabled).toBe(true);
     expect(plugins[0].path).toContain('research-claw-core');
-    expect(plugins[0].config.dbPath).toBe('.research-claw/library.db');
+    expect(plugins[0].config.dbPath).toBe('~/.research-claw/library.db');
   });
 });
 
@@ -219,4 +219,3 @@ describe('togglePlugin', () => {
     }));
   });
 });
-

--- a/dashboard/src/utils/config-patch.ts
+++ b/dashboard/src/utils/config-patch.ts
@@ -15,6 +15,7 @@ import { getPreset } from './provider-presets';
 
 /** Sentinel value OpenClaw uses to redact secrets in resolved config */
 export const REDACTED_SENTINEL = '__OPENCLAW_REDACTED__';
+const RC_DB_PATH_DEFAULT = '~/.research-claw/library.db';
 
 export interface ConfigPatchInput {
   /** OpenClaw native provider key (e.g. 'zai', 'openai', 'anthropic') */
@@ -339,7 +340,7 @@ const RC_CONFIG_DEFAULTS: Record<string, unknown> = {
       'research-claw-core': {
         enabled: true,
         config: {
-          dbPath: '.research-claw/library.db',
+          dbPath: RC_DB_PATH_DEFAULT,
           autoTrackGit: true,
           defaultCitationStyle: 'apa',
           heartbeatDeadlineWarningHours: 48,

--- a/extensions/research-claw-core/index.ts
+++ b/extensions/research-claw-core/index.ts
@@ -15,6 +15,7 @@
 import { spawn } from 'node:child_process';
 import * as fs from 'node:fs';
 import type { IncomingMessage, ServerResponse } from 'node:http';
+import * as os from 'node:os';
 import * as path from 'node:path';
 
 import { createDatabaseManager, type DatabaseManager } from './src/db/connection.js';
@@ -189,6 +190,8 @@ function resolvePptRoot(api: PluginApi, cfg: PluginConfig): string {
 
 // ── Plugin definition ──────────────────────────────────────────────────
 
+const DEFAULT_RC_DB_PATH = path.join(os.homedir(), '.research-claw', 'library.db');
+
 const plugin: PluginDefinition = {
   id: 'research-claw-core',
   name: 'Research-Claw Core',
@@ -197,7 +200,12 @@ const plugin: PluginDefinition = {
 
   register(api) {
     const cfg = (api.pluginConfig ?? {}) as PluginConfig;
-    const dbPath = api.resolvePath(cfg.dbPath ?? '.research-claw/library.db');
+    const rawDbPath = typeof cfg.dbPath === 'string' && cfg.dbPath.trim()
+      ? cfg.dbPath.trim()
+      : DEFAULT_RC_DB_PATH;
+    const dbPath = rawDbPath.startsWith('~/')
+      ? path.join(os.homedir(), rawDbPath.slice(2))
+      : api.resolvePath(rawDbPath);
     const deadlineWarningHours = cfg.heartbeatDeadlineWarningHours ?? 48;
 
     api.logger.info(`Research-Claw Core initializing (db: ${dbPath})`);

--- a/extensions/research-claw-core/openclaw.plugin.json
+++ b/extensions/research-claw-core/openclaw.plugin.json
@@ -10,7 +10,7 @@
       "dbPath": {
         "type": "string",
         "description": "Path to SQLite database file",
-        "default": ".research-claw/library.db"
+        "default": "~/.research-claw/library.db"
       },
       "autoTrackGit": {
         "type": "boolean",

--- a/scripts/ensure-config.cjs
+++ b/scripts/ensure-config.cjs
@@ -26,11 +26,36 @@ const os = require('os');
 const REQUIRED_ALLOW = ['research-claw-core', 'research-plugins', 'openclaw-weixin'];
 const RC_PLUGIN_IDS = ['research-claw-core', 'openclaw-weixin', 'research-plugins'];
 const RC_EXTENSION_DIRS = ['extensions/research-claw-core', 'extensions/openclaw-weixin'];
+const RC_DB_PATH = path.join(os.homedir(), '.research-claw', 'library.db');
 const REQUIRED_TOOLS = ['ppt_init', 'ppt_export'];
 const STALE_TOOLS = [
   'search_papers', 'get_paper', 'get_citations',
   'radar_configure', 'radar_get_config', 'radar_scan',
 ];
+
+function normalizeRcDbPath(configPath, rawPath) {
+  if (!rawPath || typeof rawPath !== 'string') return RC_DB_PATH;
+
+  const projectRoot = path.resolve(path.dirname(configPath), '..');
+  const legacyRel = '.research-claw/library.db';
+  const legacyAbs = path.join(projectRoot, '.research-claw', 'library.db');
+  const normalized = rawPath.trim();
+
+  if (
+    normalized === legacyRel ||
+    normalized === '~/.research-claw/library.db' ||
+    normalized === '$HOME/.research-claw/library.db' ||
+    normalized === legacyAbs
+  ) {
+    return RC_DB_PATH;
+  }
+
+  if (path.isAbsolute(normalized) && normalized.startsWith(path.join(projectRoot, '.research-claw') + path.sep)) {
+    return RC_DB_PATH;
+  }
+
+  return normalized;
+}
 
 function ensureConfig(filePath) {
   if (!fs.existsSync(filePath)) return false;
@@ -108,10 +133,12 @@ function ensureConfig(filePath) {
     const before = c.tools.alsoAllow.length;
     c.tools.alsoAllow = c.tools.alsoAllow.filter(t => !STALE_TOOLS.includes(t));
     if (c.tools.alsoAllow.length !== before) changed = true;
-    for (const tool of REQUIRED_TOOLS) {
-      if (!c.tools.alsoAllow.includes(tool)) {
-        c.tools.alsoAllow.push(tool);
-        changed = true;
+    if (!isGlobal) {
+      for (const tool of REQUIRED_TOOLS) {
+        if (!c.tools.alsoAllow.includes(tool)) {
+          c.tools.alsoAllow.push(tool);
+          changed = true;
+        }
       }
     }
   }
@@ -231,10 +258,23 @@ function ensureConfig(filePath) {
   if (!isGlobal && !c.plugins?.entries) {
     if (!c.plugins) c.plugins = {};
     c.plugins.entries = {
-      'research-claw-core': { enabled: true, config: { dbPath: '.research-claw/library.db', autoTrackGit: true, defaultCitationStyle: 'apa', heartbeatDeadlineWarningHours: 48, pptRoot: 'integrations/ppt-master' } },
+      'research-claw-core': { enabled: true, config: { dbPath: RC_DB_PATH, autoTrackGit: true, defaultCitationStyle: 'apa', heartbeatDeadlineWarningHours: 48, pptRoot: 'integrations/ppt-master' } },
       'openclaw-weixin': { enabled: true },
     };
     changed = true;
+  }
+
+  if (!isGlobal && c.plugins?.entries?.['research-claw-core']) {
+    const entry = c.plugins.entries['research-claw-core'];
+    if (!entry.config) {
+      entry.config = {};
+      changed = true;
+    }
+    const nextDbPath = normalizeRcDbPath(filePath, entry.config.dbPath);
+    if (entry.config.dbPath !== nextDbPath) {
+      entry.config.dbPath = nextDbPath;
+      changed = true;
+    }
   }
 
   // 12. Browser — ensure config exists with RC default profile

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -49,6 +49,31 @@ info() { printf "${C}  ▸${N} %s\n" "$1"; }
 warn() { printf "${Y}  ⚠${N} %s\n" "$1"; }
 die()  { printf "${R}  ✗ %s${N}\n" "$1" >&2; printf "  ${D}Report: ${ISSUES_URL}${N}\n" >&2; exit 1; }
 
+ensure_ppt_master() {
+  local target_dir="$INSTALL_DIR/ppt-master"
+  local scripts_root="$target_dir/skills/ppt-master/scripts"
+
+  if [ -f "$scripts_root/project_manager.py" ] && [ -f "$scripts_root/svg_to_pptx.py" ]; then
+    ok "ppt-master ready"
+    return 0
+  fi
+
+  if [ -f "$INSTALL_DIR/.gitmodules" ] && grep -q 'path = ppt-master' "$INSTALL_DIR/.gitmodules" 2>/dev/null; then
+    info "Initializing ppt-master submodule..."
+    git -C "$INSTALL_DIR" submodule sync -- ppt-master >/dev/null 2>&1 || true
+    if ! git -C "$INSTALL_DIR" submodule update --init --recursive ppt-master; then
+      die "Failed to initialize ppt-master. Try: cd $INSTALL_DIR && git submodule update --init --recursive ppt-master"
+    fi
+  fi
+
+  if [ -f "$scripts_root/project_manager.py" ] && [ -f "$scripts_root/svg_to_pptx.py" ]; then
+    ok "ppt-master ready"
+    return 0
+  fi
+
+  die "ppt-master is missing required scripts after install. Try: cd $INSTALL_DIR && git submodule update --init --recursive ppt-master"
+}
+
 # Global error trap — catch unexpected failures from set -euo pipefail
 trap 'printf "\n${R}  ✗ Unexpected error at line $LINENO${N}\n" >&2; printf "  ${D}Report: ${ISSUES_URL}${N}\n" >&2; exit 1' ERR
 
@@ -456,6 +481,8 @@ else
   ok "Cloned"
 fi
 
+ensure_ppt_master
+
 # --- Force git HTTPS (prevent SSH clone failures for git+ dependencies) ---
 # @whiskeysockets/baileys references libsignal-node via git+https URL;
 # some environments convert this to SSH (git@github.com:...) which fails
@@ -689,6 +716,7 @@ node -e "
 " 2>/dev/null || true
 
 if [ -f config/openclaw.json ]; then
+  node scripts/migrate-rc-data-dir.cjs 2>/dev/null || true
   # Clean stale references + ensure OC 2026.3.13+ required fields.
   # Shared logic in ensure-config.cjs — also called by run.sh and docker-entrypoint.sh.
   GLOBAL_CFG="$HOME/.openclaw/openclaw.json"
@@ -1225,7 +1253,11 @@ if (cfg.agents?.defaults?.workspace) {
 if (cfg.plugins?.entries) {
   for (const e of Object.values(cfg.plugins.entries)) {
     if (e?.config?.dbPath && !path.isAbsolute(e.config.dbPath)) {
-      e.config.dbPath = path.resolve(root, e.config.dbPath); changed = true;
+      if (e.config.dbPath.startsWith('~/')) {
+        e.config.dbPath = path.join(require('os').homedir(), e.config.dbPath.slice(2)); changed = true;
+      } else {
+        e.config.dbPath = path.resolve(root, e.config.dbPath); changed = true;
+      }
     }
   }
 }

--- a/scripts/migrate-rc-data-dir.cjs
+++ b/scripts/migrate-rc-data-dir.cjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const PROJECT_ROOT = path.resolve(__dirname, '..');
+const LEGACY_DIR = path.join(PROJECT_ROOT, '.research-claw');
+const TARGET_DIR = path.join(os.homedir(), '.research-claw');
+
+function hasEntries(dir) {
+  try {
+    return fs.readdirSync(dir).length > 0;
+  } catch {
+    return false;
+  }
+}
+
+function migrateDir() {
+  if (!fs.existsSync(LEGACY_DIR)) return false;
+
+  if (!fs.existsSync(TARGET_DIR)) {
+    fs.mkdirSync(path.dirname(TARGET_DIR), { recursive: true });
+    fs.renameSync(LEGACY_DIR, TARGET_DIR);
+    console.log(`[migrate-rc-data] moved ${LEGACY_DIR} -> ${TARGET_DIR}`);
+    return true;
+  }
+
+  if (!hasEntries(LEGACY_DIR)) return false;
+
+  fs.mkdirSync(TARGET_DIR, { recursive: true });
+  fs.cpSync(LEGACY_DIR, TARGET_DIR, {
+    recursive: true,
+    force: false,
+    errorOnExist: false,
+    dereference: false,
+  });
+
+  const backupDir = `${LEGACY_DIR}.migrated-to-home-${Date.now()}`;
+  fs.renameSync(LEGACY_DIR, backupDir);
+  console.log(`[migrate-rc-data] merged ${LEGACY_DIR} -> ${TARGET_DIR} (backup: ${backupDir})`);
+  return true;
+}
+
+try {
+  migrateDir();
+} catch (error) {
+  console.warn(`[migrate-rc-data] warn: ${error?.message || error}`);
+  process.exitCode = 1;
+}

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -59,6 +59,9 @@ fi
 # Without this, it reads ~/.openclaw/openclaw.json which has no RC settings.
 export OPENCLAW_CONFIG_PATH="$(pwd)/config/openclaw.json"
 
+# --- Migrate legacy project data dir to ~/.research-claw ---
+node "$(dirname "$0")/migrate-rc-data-dir.cjs" 2>/dev/null || true
+
 # Token auth — must be set BEFORE ensure-config so it can align config to this value.
 # Default 'research-claw' matches Dashboard's DEFAULT_TOKEN for zero-config local use.
 # Remote users override via: export OPENCLAW_GATEWAY_TOKEN=my-secret (before pnpm serve)


### PR DESCRIPTION
## 背景

当前 Research-Claw 默认将本地数据库放在仓库内的 `~/research-claw/.research-claw/`。这会带来两个问题：

1. 用户删除或重装仓库目录时，容易把文献库数据库一并删掉。
2. `ppt-master` 虽然以子模块形式存在，但安装阶段不会主动初始化，导致首次安装后目录可能为空，直到运行时首次调用 PPT 能力才暴露问题。

## 本次修改

### 1. 将 Research-Claw 默认数据目录迁移到 `~/.research-claw`

- 将 `research-claw-core` 默认 `dbPath` 调整为 `~/.research-claw/library.db`
- 更新 dashboard 生成默认配置时写入的新路径
- 更新示例配置与插件默认 schema
- 在 `run.sh` / `install.sh` 中增加旧目录迁移逻辑：
  - 旧路径：`~/research-claw/.research-claw`
  - 新路径：`~/.research-claw`
- `ensure-config.cjs` 会把旧的项目内数据库路径自动规范到新的家目录路径
- 新增 `scripts/migrate-rc-data-dir.cjs`，用于迁移现有本地数据

### 2. 安装阶段强制初始化 `ppt-master`

- 在 `scripts/install.sh` 中新增 `ensure_ppt_master()`
- clone / update 主仓库后立即执行 `git submodule update --init --recursive ppt-master`
- 安装阶段直接校验 `project_manager.py` / `svg_to_pptx.py` 是否存在
- 如果初始化失败，安装脚本会直接报错退出，避免留下空的 `ppt-master` 目录
- 同时补上对 `~/...` 形式 `dbPath` 的展开，避免被错误重写成仓库内路径

## 验证

已验证：

- `node -c scripts/ensure-config.cjs`
- `node -c scripts/migrate-rc-data-dir.cjs`
- `bash -n scripts/run.sh`
- `bash -n scripts/install.sh`
- `pnpm --filter dashboard test src/stores/extensions.test.ts src/components/panels/ExtensionsPanel.test.tsx src/utils/config-patch.test.ts`

说明：在干净 worktree 中没有安装 `node_modules`，因此无法在该 worktree 独立运行前端测试；但同一组改动已在主工作区完成测试通过。

## 影响

- 后续删除 `~/research-claw` 时，不会再顺带删除 `~/.research-claw/library.db`
- 新安装流程会在安装阶段就把 `ppt-master` 拉齐，减少首次使用 PPT 功能时的空目录问题
