### PR TITLE
fix(installer): prepare native Profile data root

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -624,6 +624,34 @@ rc_profile_assert_gateway_stopped() {
   fi
 }
 
+rc_profile_prepare_native_data_root() {
+  local _data_root _created=false _owner _mode
+  case "${HOME:-}" in
+    /*) _data_root="$HOME/.research-claw" ;;
+    *) die "The home directory is unavailable; refusing to prepare the Research-Claw data directory." ;;
+  esac
+
+  [ ! -L "$_data_root" ] \
+    || die "The Research-Claw data path is a symbolic link; refusing to apply a Bootstrap Profile."
+  if [ ! -e "$_data_root" ]; then
+    (umask 077; mkdir -- "$_data_root") \
+      || die "Could not create the Research-Claw data directory."
+    _created=true
+  fi
+  [ -d "$_data_root" ] && [ ! -L "$_data_root" ] \
+    || die "The Research-Claw data path is not a concrete directory."
+  _owner="$(rc_install_path_owner "$_data_root")" \
+    || die "Could not verify the Research-Claw data directory owner."
+  [ "$_owner" = "$(id -u)" ] \
+    || die "The Research-Claw data directory is not owned by the current user."
+  if $_created; then
+    _mode="$(rc_install_path_mode "$_data_root")" \
+      || die "Could not verify the Research-Claw data directory permissions."
+    [ "$_mode" = 700 ] \
+      || die "The new Research-Claw data directory is not private."
+  fi
+}
+
 rc_profile_recover_native() {
   rc_profile_native_cli initialize-locks >/dev/null
   rc_profile_native_cli recover >/dev/null
@@ -2030,6 +2058,7 @@ fi  # end: if ! $UPDATE_FAILED (skip build/install/plugins)
 if [ -n "$RC_PROFILE_CAPSULE" ]; then
   $UPDATE_FAILED && die "The 0.8.3 candidate was not installed; refusing to apply a new Bootstrap Profile."
   rc_profile_assert_gateway_stopped
+  rc_profile_prepare_native_data_root
   rc_profile_recover_native
   rc_profile_stage_native
   rc_profile_apply_native

--- a/test/bootstrap-profile-installer-native-runtime.test.ts
+++ b/test/bootstrap-profile-installer-native-runtime.test.ts
@@ -200,6 +200,69 @@ test -z "$(find "$TMPDIR" -mindepth 1 -maxdepth 1 -print -quit)"
   );
 
   it.skipIf(process.platform === 'win32')(
+    'creates the missing native Profile data root privately and rejects unsafe existing paths',
+    () => {
+      const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'rc-native-profile-data-root-'));
+      roots.push(sandbox);
+      const runner = path.join(sandbox, 'profile-data-root-runner.sh');
+      const installer = fs.readFileSync(INSTALLER, 'utf8');
+      const lifecycle = extractBetween(
+        installer,
+        'RC_BOOTSTRAP_REDEEM_URL=',
+        '\nrc_profile_parse_args "$@"',
+      );
+      fs.writeFileSync(runner, `#!/usr/bin/env bash
+set -euo pipefail
+R='' G='' C='' Y='' B='' D='' N=''
+ISSUES_URL=https://invalid.example/issues
+die() { printf 'fixture-die: %s\\n' "$1" >&2; exit 1; }
+${lifecycle}
+rc_profile_prepare_native_data_root
+`, { mode: 0o700 });
+
+      const run = (home: string) => spawnSync('/bin/bash', [runner], {
+        encoding: 'utf8',
+        env: { PATH: '/usr/bin:/bin', HOME: home },
+      });
+
+      const freshHome = path.join(sandbox, 'fresh-home');
+      fs.mkdirSync(freshHome, { mode: 0o700 });
+      const fresh = run(freshHome);
+      expect(fresh.status, `${fresh.stdout}\n${fresh.stderr}`).toBe(0);
+      const freshDataRoot = path.join(freshHome, '.research-claw');
+      expect(fs.statSync(freshDataRoot).mode & 0o777).toBe(0o700);
+
+      const existingHome = path.join(sandbox, 'existing-home');
+      const existingDataRoot = path.join(existingHome, '.research-claw');
+      fs.mkdirSync(existingDataRoot, { recursive: true, mode: 0o700 });
+      fs.writeFileSync(path.join(existingDataRoot, 'user-owned.txt'), 'preserve\n');
+      const existing = run(existingHome);
+      expect(existing.status, `${existing.stdout}\n${existing.stderr}`).toBe(0);
+      expect(fs.readFileSync(path.join(existingDataRoot, 'user-owned.txt'), 'utf8')).toBe(
+        'preserve\n',
+      );
+
+      const symlinkHome = path.join(sandbox, 'symlink-home');
+      const symlinkTarget = path.join(sandbox, 'symlink-target');
+      fs.mkdirSync(symlinkHome, { mode: 0o700 });
+      fs.mkdirSync(symlinkTarget, { mode: 0o700 });
+      fs.symlinkSync(symlinkTarget, path.join(symlinkHome, '.research-claw'));
+      const symlink = run(symlinkHome);
+      expect(symlink.status).not.toBe(0);
+      expect(fs.readdirSync(symlinkTarget)).toEqual([]);
+
+      const fileHome = path.join(sandbox, 'file-home');
+      fs.mkdirSync(fileHome, { mode: 0o700 });
+      fs.writeFileSync(path.join(fileHome, '.research-claw'), 'not-a-directory\n');
+      const file = run(fileHome);
+      expect(file.status).not.toBe(0);
+      expect(fs.readFileSync(path.join(fileHome, '.research-claw'), 'utf8')).toBe(
+        'not-a-directory\n',
+      );
+    },
+  );
+
+  it.skipIf(process.platform === 'win32')(
     'roots the generated openclaw wrapper at the installation from any caller directory',
     () => {
       const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'rc-native-openclaw-wrapper-'));

--- a/test/bootstrap-profile-installer-wiring.test.ts
+++ b/test/bootstrap-profile-installer-wiring.test.ts
@@ -138,6 +138,7 @@ describe('Bootstrap Profile installer transaction ordering', () => {
       'rc_profile_redeem',
       'git clone',
       'rc_profile_assert_gateway_stopped',
+      'rc_profile_prepare_native_data_root',
       'rc_profile_recover_native',
       'rc_profile_stage_native',
       'rc_profile_apply_native',


### PR DESCRIPTION
## Summary

- create a missing native Profile data root privately before the first transaction
- preserve an existing current-user-owned directory
- reject symlink, file, and foreign-owner paths before Profile mutation
- add runtime and ordering coverage

## Validation

- bash -n scripts/install.sh
- focused installer tests: 20/20
- strict Bootstrap + privacy suite: 37 files, 772 tests

This hotfix closes the fresh native Token install UNSAFE_PATH failure discovered during the Weifang University production Profile acceptance.