### PR TITLE
fix(windows): require PS5-safe native installer bytes

### DIFF
--- a/.github/workflows/windows-installer-contract.yml
+++ b/.github/workflows/windows-installer-contract.yml
@@ -18,6 +18,14 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
+      - name: Native installer encoding and parser on Windows PowerShell 5.1
+        shell: powershell
+        run: .\scripts\verify-native-windows-installer-encoding.ps1 -InstallerPath .\scripts\install-windows.ps1 -ExpectedEdition Desktop -ExpectedMajorVersion 5
+
+      - name: Native installer encoding and parser on PowerShell 7
+        shell: pwsh
+        run: .\scripts\verify-native-windows-installer-encoding.ps1 -InstallerPath .\scripts\install-windows.ps1 -ExpectedEdition Core -ExpectedMajorVersion 7
+
       - name: Windows PowerShell 5.1 parser and error behavior
         shell: powershell
         run: .\scripts\verify-installer-powershell.ps1 -ExpectedEdition Desktop -ExpectedMajorVersion 5 -AcceptanceHarnessPath .\scripts\acceptance\windows-bootstrap-docker.ps1

--- a/scripts/install-windows.ps1
+++ b/scripts/install-windows.ps1
@@ -1,4 +1,4 @@
-param([string]$AuthToken)
+﻿param([string]$AuthToken)
 
 if ($args.Count -ne 0) {
     throw 'Unknown installer argument.'

--- a/scripts/verify-native-windows-installer-encoding.ps1
+++ b/scripts/verify-native-windows-installer-encoding.ps1
@@ -1,0 +1,77 @@
+param(
+    [Parameter(Mandatory = $true)][string]$InstallerPath,
+    [Parameter(Mandatory = $true)][ValidateSet('Desktop', 'Core')][string]$ExpectedEdition,
+    [Parameter(Mandatory = $true)][int]$ExpectedMajorVersion
+)
+
+$ErrorActionPreference = 'Stop'
+
+if ($env:OS -cne 'Windows_NT') {
+    throw 'This verifier requires native Windows.'
+}
+if (-not [System.Environment]::Is64BitOperatingSystem -or
+    -not [System.Environment]::Is64BitProcess) {
+    throw 'This verifier requires a 64-bit Windows process and OS.'
+}
+$processorArchitecture = [string]$env:PROCESSOR_ARCHITECTURE
+if ($processorArchitecture -cne 'AMD64') {
+    throw "Expected AMD64 process architecture; observed $processorArchitecture."
+}
+$processors = @(Get-CimInstance Win32_Processor -ErrorAction Stop)
+if ($processors.Count -lt 1 -or @($processors | Where-Object { $_.Architecture -ne 9 }).Count -ne 0) {
+    throw 'This verifier requires an x64 Windows processor contract.'
+}
+if ($PSVersionTable.PSEdition -cne $ExpectedEdition) {
+    throw "PowerShell edition mismatch: expected $ExpectedEdition."
+}
+if ($PSVersionTable.PSVersion.Major -ne $ExpectedMajorVersion) {
+    throw "PowerShell major version mismatch: expected $ExpectedMajorVersion."
+}
+
+$resolved = (Resolve-Path -LiteralPath $InstallerPath -ErrorAction Stop).Path
+$item = Get-Item -LiteralPath $resolved -Force -ErrorAction Stop
+if (-not $item.PSIsContainer -and ($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -eq 0) {
+    $bytes = [System.IO.File]::ReadAllBytes($resolved)
+} else {
+    throw 'Installer must be a regular non-reparse file.'
+}
+if ($bytes.Length -le 3 -or
+    $bytes[0] -ne 0xEF -or $bytes[1] -ne 0xBB -or $bytes[2] -ne 0xBF) {
+    throw 'Native Windows installer must be UTF-8 with BOM.'
+}
+
+$utf8NoBom = New-Object System.Text.UTF8Encoding($false, $true)
+$installerText = $utf8NoBom.GetString($bytes, 3, $bytes.Length - 3)
+if ($installerText.IndexOf([char]0xFFFD) -ge 0) {
+    throw 'Native Windows installer contains a replacement character.'
+}
+$tokens = $null
+$parseErrors = $null
+[void][System.Management.Automation.Language.Parser]::ParseInput(
+    $installerText,
+    $resolved,
+    [ref]$tokens,
+    [ref]$parseErrors
+)
+if ($parseErrors.Count -ne 0) {
+    $messages = @($parseErrors | ForEach-Object { $_.Message }) -join ' | '
+    throw "Native Windows installer parse failed: $messages"
+}
+
+$algorithm = [System.Security.Cryptography.SHA256]::Create()
+try {
+    $sha256 = ([BitConverter]::ToString($algorithm.ComputeHash($bytes))).Replace('-', '').ToLowerInvariant()
+} finally {
+    $algorithm.Dispose()
+}
+
+[ordered]@{
+    ok = $true
+    osArchitecture = 'x64'
+    processArchitecture = $processorArchitecture
+    powerShellEdition = [string]$PSVersionTable.PSEdition
+    powerShellVersion = [string]$PSVersionTable.PSVersion
+    utf8Bom = $true
+    parseErrors = 0
+    installerSha256 = $sha256
+} | ConvertTo-Json -Compress

--- a/test/windows-native-installer-encoding.test.ts
+++ b/test/windows-native-installer-encoding.test.ts
@@ -1,0 +1,56 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const ROOT = path.resolve(__dirname, '..');
+const INSTALLER = path.join(ROOT, 'scripts', 'install-windows.ps1');
+const VERIFIER = path.join(
+  ROOT,
+  'scripts',
+  'verify-native-windows-installer-encoding.ps1',
+);
+const WORKFLOW = path.join(
+  ROOT,
+  '.github',
+  'workflows',
+  'windows-installer-contract.yml',
+);
+const UTF8_BOM = Buffer.from([0xEF, 0xBB, 0xBF]);
+
+describe('native Windows installer byte encoding', () => {
+  it('is strict UTF-8 with a BOM for Windows PowerShell 5.1 on DBCS hosts', () => {
+    const bytes = fs.readFileSync(INSTALLER);
+    expect(bytes.subarray(0, UTF8_BOM.length)).toEqual(UTF8_BOM);
+
+    const text = new TextDecoder('utf-8', { fatal: true }).decode(
+      bytes.subarray(UTF8_BOM.length),
+    );
+    expect(text).toMatch(/[^\u0000-\u007F]/u);
+    expect(text).not.toContain('\uFFFD');
+    expect(text.startsWith('param([string]$AuthToken)')).toBe(true);
+  });
+
+  it('is parsed from the same byte snapshot by PS5.1 and PS7 on Windows x64', () => {
+    const verifier = fs.readFileSync(VERIFIER, 'utf8');
+    expect(verifier).toContain('[System.IO.File]::ReadAllBytes($resolved)');
+    expect(verifier).toContain('$bytes[0] -ne 0xEF');
+    expect(verifier).toContain('New-Object System.Text.UTF8Encoding($false, $true)');
+    expect(verifier).toContain(
+      '[System.Management.Automation.Language.Parser]::ParseInput',
+    );
+    expect(verifier).toContain("$processorArchitecture -cne 'AMD64'");
+    expect(verifier).toContain('$PSVersionTable.PSEdition -cne $ExpectedEdition');
+    expect(verifier).toContain('$PSVersionTable.PSVersion.Major -ne $ExpectedMajorVersion');
+
+    const workflow = fs.readFileSync(WORKFLOW, 'utf8');
+    const calls = workflow.match(
+      /verify-native-windows-installer-encoding\.ps1/g,
+    ) ?? [];
+    expect(calls).toHaveLength(2);
+    expect(workflow).toContain(
+      '-ExpectedEdition Desktop -ExpectedMajorVersion 5',
+    );
+    expect(workflow).toContain('-ExpectedEdition Core -ExpectedMajorVersion 7');
+  });
+});


### PR DESCRIPTION
## Root cause\n\nThe native Windows entrypoint contained non-ASCII text but was stored as UTF-8 without a BOM. Windows PowerShell 5.1 on a Chinese DBCS host decoded those bytes through the active ANSI code page, which corrupted quoted strings and caused cascading parser errors.\n\n## Fix\n\n- store the native entrypoint as UTF-8 with BOM\n- add an ASCII-only verifier that binds native Windows x64, the exact PS edition/version, BOM, strict UTF-8 decoding, same-snapshot parsing, and SHA-256\n- run the verifier under Windows PowerShell 5.1 and PowerShell 7 in the Windows workflow\n- add byte-level regression coverage\n\n## Boundary\n\nThis PR is a candidate only. Do not retag or publish until the final offline ZIP is audited and parsed from its extracted bytes on the target Windows host.